### PR TITLE
Change the color of the a tags on the website

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,7 +12,7 @@ html {
   scroll-behavior: smooth;
 }
 
-a:active, a:visited {
+a:active, a:visited, a {
   color: black;
 }
 


### PR DESCRIPTION
This PR makes it so that the links are black when the page first loads instead of blue, which was throwing off the color scheme.